### PR TITLE
As notificações magento não estão sendo enviadas para determinadas ações TKR-2491

### DIFF
--- a/code/Aftersale/NotificationOrder/Model/OrderObserver.php
+++ b/code/Aftersale/NotificationOrder/Model/OrderObserver.php
@@ -17,10 +17,21 @@ class Aftersale_NotificationOrder_Model_OrderObserver
     public function orderCreateOrUpdate($observer)
     {
         try {
+            $order = $observer->getOrder()->getData();
 
-            $content = $observer->getOrder()->getData();
+            $this->orderNotificationService->send($order);
+        } catch (\Exception $exception) {
+            Mage::log($exception->getMessage(), null, 'webhookError.log');
+            $this->orderNotificationService->dispatchEmail($exception->getMessage());
+        }
+    }
 
-            $this->orderNotificationService->send($content);
+    public function orderShipmentCreateOrUpdate($observer)
+    {
+        try {
+            $order = $observer->getEvent()->getShipment()->getOrder()->getData();
+
+            $this->orderNotificationService->send($order);
         } catch (\Exception $exception) {
             Mage::log($exception->getMessage(), null, 'webhookError.log');
             $this->orderNotificationService->dispatchEmail($exception->getMessage());

--- a/code/Aftersale/NotificationOrder/etc/config.xml
+++ b/code/Aftersale/NotificationOrder/etc/config.xml
@@ -17,7 +17,7 @@
             </aftersale_notificationOrder>
         </models>
         <events>
-            <sales_order_place_after>
+            <sales_order_save_after>
                 <observers>
                     <aftersale_notificationOrder>
                         <class>aftersale_notificationOrder/orderObserver</class>
@@ -25,7 +25,7 @@
                         <type>singleton</type>
                     </aftersale_notificationOrder>
                 </observers>
-            </sales_order_place_after>
+            </sales_order_save_after>
         </events>
     </global>
 </config>

--- a/code/Aftersale/NotificationOrder/etc/config.xml
+++ b/code/Aftersale/NotificationOrder/etc/config.xml
@@ -26,6 +26,15 @@
                     </aftersale_notificationOrder>
                 </observers>
             </sales_order_save_after>
+            <sales_order_shipment_save_after>
+                <observers>
+                    <aftersale_notificationOrder>
+                        <class>aftersale_notificationOrder/orderObserver</class>
+                        <method>orderShipmentCreateOrUpdate</method>
+                        <type>singleton</type>
+                    </aftersale_notificationOrder>
+                </observers>
+            </sales_order_shipment_save_after>
         </events>
     </global>
 </config>


### PR DESCRIPTION
### Problema 

Ao realizar testes no plugin magento, algumas ações realizadas pelo usuário que alteram o status do pedido não estão sendo notificados ao webhook.

### Solução

Adicionar novo evento sales_order_save_after e sales_order_shipment_save_after

### Observação 

Não fiz um teste para o método orderShipmentCreateOrUpdate pois passa os mesmo valores que o orderCreateOrUpdate 