### PR TITLE
TKR-2753 [MAGENTO WEBHOOK] O plugin não esta disparando eventos como esperado [Staging]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ```bash
 cd [magento root folder]
 modman init
-modman clone https://github.com/tiagobrunoBFR/notification-order-magento.git
+modman clone https://github.com/Send4BR/notification-order-magentov1.git
 ```
 - Flush Magento's cache
 

--- a/code/Aftersale/NotificationOrder/Services/WebhookServer.php
+++ b/code/Aftersale/NotificationOrder/Services/WebhookServer.php
@@ -14,6 +14,7 @@ class WebhookServer
         curl_setopt($handle, CURLOPT_POSTFIELDS, $encodeData);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($handle, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, false);
 
         $result = json_decode(curl_exec($handle));
 


### PR DESCRIPTION
### PROBLEMA INICIAL
O plugin de webhook criado para ser instalado nas lojas MAGENTO não está enviando eventos. Os eventos precisam ser disparados para que o TRAKR atualizar os pedidos na base.

- Problema identificado pelo dev.
Foi identificado que o curl não estava conseguindo fazer a validação do certificado ssl do par.

### SOLUÇÃO
- [x] Desabilitar a validação do certificado SSL da requisição curl `curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, false);`;